### PR TITLE
#9 - Use floats for dimensions instead of ints

### DIFF
--- a/src/FedexRest/Entity/Dimensions.php
+++ b/src/FedexRest/Entity/Dimensions.php
@@ -7,36 +7,36 @@ namespace FedexRest\Entity;
  */
 class Dimensions
 {
-    public ?int $width;
-    public ?int $height;
-    public ?int $length;
+    public ?float $width;
+    public ?float $height;
+    public ?float $length;
     public string $units = '';
 
     /**
-     * @param  int  $length
+     * @param  float  $length
      * @return $this
      */
-    public function setLength(int $length): Dimensions
+    public function setLength(float $length): Dimensions
     {
         $this->length = $length;
         return $this;
     }
 
     /**
-     * @param  int  $width
+     * @param  float  $width
      * @return $this
      */
-    public function setWidth(int $width): Dimensions
+    public function setWidth(float $width): Dimensions
     {
         $this->width = $width;
         return $this;
     }
 
     /**
-     * @param  int  $height
+     * @param  float  $height
      * @return $this
      */
-    public function setHeight(int $height): Dimensions
+    public function setHeight(float $height): Dimensions
     {
         $this->height = $height;
         return $this;

--- a/tests/FedexRest/Tests/Ship/CreateShipmentTest.php
+++ b/tests/FedexRest/Tests/Ship/CreateShipmentTest.php
@@ -169,7 +169,7 @@ class CreateShipmentTest extends TestCase
                     )
                     ->setDimensions((new Dimensions())
                         ->setWidth(12)
-                        ->setLength(12)
+                        ->setLength(12.25)
                         ->setHeight(12)
                         ->setUnits(LinearUnits::_INCH)
                     )
@@ -220,8 +220,8 @@ class CreateShipmentTest extends TestCase
                             ->setUnit(WeightUnits::_POUND)
                     )
                     ->setDimensions((new Dimensions())
-                        ->setWidth(12)
-                        ->setLength(12)
+                        ->setWidth(12.5)
+                        ->setLength(12.5)
                         ->setHeight(12)
                         ->setUnits(LinearUnits::_INCH)
                     ))->request();
@@ -307,9 +307,9 @@ class CreateShipmentTest extends TestCase
                         ->setUnit(WeightUnits::_POUND)
                 )
                 ->setDimensions((new Dimensions())
-                    ->setWidth(12)
-                    ->setLength(12)
-                    ->setHeight(12)
+                    ->setWidth(12.5)
+                    ->setLength(12.5)
+                    ->setHeight(12.5)
                     ->setUnits(LinearUnits::_INCH)
                 ));
         $prepared = $request->prepare();


### PR DESCRIPTION
This PR aims to set the dimensions entity to use floats instead of integers.