### PR TITLE
15 person entity param mismatch

### DIFF
--- a/src/FedexRest/Entity/Person.php
+++ b/src/FedexRest/Entity/Person.php
@@ -64,8 +64,8 @@ class Person
         if (!empty($this->phoneNumber)) {
             $data['contact']['phoneNumber'] = $this->phoneNumber;
         }
-        if (!empty($this->company_name)) {
-            $data['contact']['companyName'] = $this->company_name;
+        if (!empty($this->companyName)) {
+            $data['contact']['companyName'] = $this->companyName;
         }
 
         if ($this->address != null) {


### PR DESCRIPTION
Renames the company name parameter in the person entity, so that the value may be used in the shipping calls.