### PR TITLE
Add support for Smart Post (now "Ground Economy") service

### DIFF
--- a/src/FedexRest/Services/Rates/CreateRatesRequest.php
+++ b/src/FedexRest/Services/Rates/CreateRatesRequest.php
@@ -31,6 +31,10 @@ class CreateRatesRequest extends AbstractRequest
     protected int $totalWeight;
     protected string $preferredCurrency = '';
     protected int $totalPackageCount;
+    protected bool $returnTransitTimes = false;
+    protected bool $servicesNeededOnRateFailure = false;
+    protected ?string $variableOptions;
+    protected ?string $rateSortOrder;
 
     /**
      * {@inheritDoc}
@@ -279,6 +283,71 @@ class CreateRatesRequest extends AbstractRequest
         return $this->totalPackageCount;
     }
 
+    public function setReturnTransitTimes(bool $returnTransitTimes=true): CreateRatesRequest
+    {
+        $this->returnTransitTimes = $returnTransitTimes;
+        return $this;
+    }
+
+    public function getReturnTransitTimes(): bool
+    {
+        return $this->returnTransitTimes;
+    }
+
+    public function setServicesNeededOnRateFailure(bool $servicesNeededOnRateFailure=true): CreateRatesRequest
+    {
+        $this->servicesNeededOnRateFailure = $servicesNeededOnRateFailure;
+        return $this;
+    }
+
+    public function getServicesNeededOnRateFailure(): bool
+    {
+        return $this->servicesNeededOnRateFailure;
+    }
+
+    public function setVariableOptions(?string $variableOptions): CreateRatesRequest
+    {
+        $this->variableOptions = $variableOptions;
+        return $this;
+    }
+
+    public function getVariableOptions(): ?string
+    {
+        return $this->variableOptions;
+    }
+
+    public function setRateSortOrder(?string $rateSortOrder): CreateRatesRequest
+    {
+        $this->rateSortOrder = $rateSortOrder;
+        return $this;
+    }
+
+    public function getRateSortOrder(): ?string
+    {
+        return $this->rateSortOrder;
+    }
+
+    /**
+     * @return array
+     */
+    public function getControlParameters(): array
+    {
+        $data = [
+            'returnTransitTimes' => $this->returnTransitTimes,
+            'servicesNeededOnRateFailure' => $this->servicesNeededOnRateFailure,
+        ];
+
+        if ($this->variableOptions) {
+            $data['variableOptions'] = $this->variableOptions;
+        }
+
+        if ($this->rateSortOrder) {
+            $data['rateSortOrder'] = $this->rateSortOrder;
+        }
+
+        return $data;
+    }
+
     /**
      * @return array
      */
@@ -338,6 +407,7 @@ class CreateRatesRequest extends AbstractRequest
             'accountNumber' => [
                 'value' => $this->accountNumber,
             ],
+            'rateRequestControlParameters' => $this->getControlParameters(),
             'requestedShipment' => $this->getRequestedShipment(),
         ];
     }

--- a/src/FedexRest/Services/Rates/CreateRatesRequest.php
+++ b/src/FedexRest/Services/Rates/CreateRatesRequest.php
@@ -33,8 +33,8 @@ class CreateRatesRequest extends AbstractRequest
     protected int $totalPackageCount;
     protected bool $returnTransitTimes = false;
     protected bool $servicesNeededOnRateFailure = false;
-    protected ?string $variableOptions;
-    protected ?string $rateSortOrder;
+    protected ?string $variableOptions = null;
+    protected ?string $rateSortOrder = null;
 
     /**
      * {@inheritDoc}

--- a/src/FedexRest/Services/Rates/CreateRatesRequest.php
+++ b/src/FedexRest/Services/Rates/CreateRatesRequest.php
@@ -35,6 +35,7 @@ class CreateRatesRequest extends AbstractRequest
     protected bool $servicesNeededOnRateFailure = false;
     protected ?string $variableOptions = null;
     protected ?string $rateSortOrder = null;
+    protected array $carrierCodes = [];
 
     /**
      * {@inheritDoc}
@@ -328,6 +329,24 @@ class CreateRatesRequest extends AbstractRequest
     }
 
     /**
+     * Set the list of Carrier Codes to request rates from.
+     *
+     * Documentation is not clear on what the default is when not specified, but as of
+     * 2024-05-30 the default appears to be ['FDXE', 'FDXG']. You must explicitly include
+     * 'FXSP' to obtain SmartPost rates
+     */
+    public function setCarrierCodes(array $carrierCodes): CreateRatesRequest
+    {
+        $this->carrierCodes = $carrierCodes;
+        return $this;
+    }
+
+    public function getCarrierCodes(): array
+    {
+        return $this->carrierCodes;
+    }
+
+    /**
      * @return array
      */
     public function getControlParameters(): array
@@ -409,6 +428,7 @@ class CreateRatesRequest extends AbstractRequest
             ],
             'rateRequestControlParameters' => $this->getControlParameters(),
             'requestedShipment' => $this->getRequestedShipment(),
+            'carrierCodes' => $this->getCarrierCodes(),
         ];
     }
 
@@ -429,13 +449,7 @@ class CreateRatesRequest extends AbstractRequest
         }
 
         try {
-          $prepare = $this->prepare();
-//          unset($prepare['requestedShipment']['requestedPackageLineItems'][0]['dimensions']);
-//          unset($prepare['requestedShipment']['requestedPackageLineItems'][0]['groupPackageCount']);
-//          unset($prepare['requestedShipment']['requestedPackageLineItems'][0]['sequenceNumber']);
-//          unset($prepare['requestedShipment']['requestedPackageLineItems'][0]['subPackagingType']);
-//          unset($prepare['requestedShipment']['requestedPackageLineItems'][0]['itemDescription']);
-//          unset($prepare['requestedShipment']['totalPackageCount']);
+            $prepare = $this->prepare();
             $query = $this->http_client->post($this->getApiUri($this->api_endpoint), [
                 'json' => $prepare,
                 'http_errors' => false,

--- a/src/FedexRest/Services/Ship/CreateShipment.php
+++ b/src/FedexRest/Services/Ship/CreateShipment.php
@@ -37,6 +37,7 @@ class CreateShipment extends AbstractRequest
     protected string $recipientLocationNumber = '';
     protected int $totalWeight;
     protected Person $origin;
+    protected SmartPostInfoDetail $smartPostInfoDetail;
     protected bool $blockInsightVisibility = FALSE;
     protected bool $oneLabelAtATime = FALSE;
     protected string $preferredCurrency = '';
@@ -380,6 +381,17 @@ class CreateShipment extends AbstractRequest
         return $this->origin;
     }
 
+    public function setSmartPostInfoDetail(?SmartPostInfoDetail $smartPostInfoDetail): CreateShipment
+    {
+        $this->smartPostInfoDetail = $smartPostInfoDetail;
+        return $this;
+    }
+
+    public function getSmartPostInfoDetail(): ?SmartPostInfoDetail
+    {
+        return $this->smartPostInfoDetail;
+    }
+
     /**
      * @param  bool  $blockInsightVisibility
      * @return $this
@@ -497,6 +509,9 @@ class CreateShipment extends AbstractRequest
         }
         if (!empty($this->origin)) {
             $data['origin'] = $this->origin->prepare();
+        }
+        if (!empty($this->smartPostInfoDetail)) {
+            $data['smartPostInfoDetail'] = $this->smartPostInfoDetail->prepare();
         }
         if (!empty($this->preferredCurrency)) {
             $data['preferredCurrency'] = $this->preferredCurrency;

--- a/src/FedexRest/Services/Ship/CreateShipment.php
+++ b/src/FedexRest/Services/Ship/CreateShipment.php
@@ -7,6 +7,7 @@ use FedexRest\Services\Ship\Entity\Label;
 use FedexRest\Entity\Person;
 use FedexRest\Services\Ship\Entity\ShipmentSpecialServices;
 use FedexRest\Services\Ship\Entity\ShippingChargesPayment;
+use FedexRest\Services\Ship\Entity\SmartPostInfoDetail;
 use FedexRest\Services\Ship\Entity\Value;
 use FedexRest\Exceptions\MissingAccountNumberException;
 use FedexRest\Services\Ship\Exceptions\MissingLabelException;

--- a/src/FedexRest/Services/Ship/Entity/SmartPostInfoDetail.php
+++ b/src/FedexRest/Services/Ship/Entity/SmartPostInfoDetail.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace FedexRest\Services\Ship\Entity;
+
+class SmartPostInfoDetail
+{
+    public ?string $ancillaryEndorsement;
+    public ?string $hubId;
+    public ?string $indicia;
+    public ?string $specialServices;
+
+    public function setAncillaryEndorsement(?string $ancillaryEndorsement): static
+    {
+        $this->ancillaryEndorsement = $ancillaryEndorsement;
+        return $this;
+    }
+
+    public function setHubId(?string $hubId): static
+    {
+        $this->hubId = $hubId;
+        return $this;
+    }
+
+    public function setIndicia(?string $indicia): static
+    {
+        $this->indicia = $indicia;
+        return $this;
+    }
+
+    public function setSpecialServices(?string $specialServices): static
+    {
+        $this->specialServices = $specialServices;
+        return $this;
+    }
+
+    public function prepare(): array
+    {
+        $data = [];
+        if (!empty($this->ancillaryEndorsement)) {
+            $data['ancillaryEndorsement'] = $this->ancillaryEndorsement;
+        }
+        if (!empty($this->hubId)) {
+            $data['hubId'] = $this->hubId;
+        }
+        if (!empty($this->indicia)) {
+            $data['indicia'] = $this->indicia;
+        }
+        if (!empty($this->specialServices)) {
+            $data['specialServices'] = $this->specialServices;
+        }
+        return $data;
+    }
+}

--- a/src/FedexRest/Services/Ship/Type/AncillaryEndorsementType.php
+++ b/src/FedexRest/Services/Ship/Type/AncillaryEndorsementType.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace FedexRest\Services\Ship\Type;
+
+class AncillaryEncorsementType
+{
+    const _ADDRESS_CORRECTION = 'ADDRESS_CORRECTION';
+    const _CARRIER_LEAVE_IF_NO_RESPONSE = 'CARRIER_LEAVE_IF_NO_RESPONSE';
+    const _CHANGE_SERVICE = 'CHANGE_SERVICE';
+    const _FORWARDING_SERVICE = 'FORWARDING_SERVICE';
+    const _RETURN_SERVICE = 'RETURN_SERVICE';
+}

--- a/src/FedexRest/Services/Ship/Type/IndiciaType.php
+++ b/src/FedexRest/Services/Ship/Type/IndiciaType.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace FedexRest\Services\Ship\Type;
+
+class IndiciaType
+{
+    const _MEDIA_MAIL = 'MEDIA_MAIL';
+    const _PARCEL_RETURN = 'PARCEL_RETURN';
+    const _PARCEL_SELECT = 'PARCEL_SELECT';
+    const _PRESORTED_BOUND_PRINTED_MATTER = 'PRESORTED_BOUND_PRINTED_MATTER';
+    const _PRESORTED_STANDARD = 'PRESORTED_STANDARD';
+}

--- a/src/FedexRest/Services/Ship/Type/SpecialServiceType.php
+++ b/src/FedexRest/Services/Ship/Type/SpecialServiceType.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace FedexRest\Services\Ship\Type;
+
+class SpecialServiceType
+{
+    const _USPS_DELIVERY_CONFIRMATION = 'USPS_DELIVERY_CONFIRMATION';
+}


### PR DESCRIPTION
Adds enough support to the Rate and Ship services to obtain rate information and create a Smart Post shipment.

Note this branch builds on top of my other "rateRequestControlParameter" PR, so until if/when that PR merges this diff will appear to contain that as well.