### PR TITLE
Allow label specifications and email notifications in create tag request

### DIFF
--- a/src/FedexRest/Services/Ship/CreateTagRequest.php
+++ b/src/FedexRest/Services/Ship/CreateTagRequest.php
@@ -4,9 +4,14 @@ namespace FedexRest\Services\Ship;
 
 use FedexRest\Entity\Item;
 use FedexRest\Entity\Person;
+use FedexRest\Exceptions\MissingAccessTokenException;
 use FedexRest\Exceptions\MissingAccountNumberException;
 use FedexRest\Exceptions\MissingLineItemException;
 use FedexRest\Services\AbstractRequest;
+use FedexRest\Services\Ship\Entity\EmailNotificationDetail;
+use FedexRest\Services\Ship\Entity\Label;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
 
 class CreateTagRequest extends AbstractRequest
 {
@@ -18,6 +23,8 @@ class CreateTagRequest extends AbstractRequest
     protected string $packaging_type;
     protected string $pickup_type;
     protected string $ship_datestamp = '';
+    protected Label $label;
+    protected EmailNotificationDetail $emailNotificationDetail;
 
     /**
      * @inheritDoc
@@ -36,7 +43,7 @@ class CreateTagRequest extends AbstractRequest
     }
 
     /**
-     * @param  string  $pickup_type
+     * @param string $pickup_type
      * @return CreateTagRequest
      */
     public function setPickupType(string $pickup_type): CreateTagRequest
@@ -54,7 +61,7 @@ class CreateTagRequest extends AbstractRequest
     }
 
     /**
-     * @param  string  $packaging_type
+     * @param string $packaging_type
      * @return CreateTagRequest
      */
     public function setPackagingType(string $packaging_type): CreateTagRequest
@@ -72,7 +79,7 @@ class CreateTagRequest extends AbstractRequest
     }
 
     /**
-     * @param  Item  $line_items
+     * @param Item $line_items
      * @return $this
      */
     public function setLineItems(Item $line_items): CreateTagRequest
@@ -82,7 +89,7 @@ class CreateTagRequest extends AbstractRequest
     }
 
     /**
-     * @param  string  $ship_datestamp
+     * @param string $ship_datestamp
      * @return CreateTagRequest
      */
     public function setShipDatestamp(string $ship_datestamp): CreateTagRequest
@@ -92,7 +99,7 @@ class CreateTagRequest extends AbstractRequest
     }
 
     /**
-     * @param  mixed  $service_type
+     * @param mixed $service_type
      * @return CreateTagRequest
      */
     public function setServiceType(string $service_type): CreateTagRequest
@@ -126,7 +133,7 @@ class CreateTagRequest extends AbstractRequest
     }
 
     /**
-     * @param  Person  $shipper
+     * @param Person $shipper
      * @return $this
      */
     public function setShipper(Person $shipper): CreateTagRequest
@@ -136,7 +143,37 @@ class CreateTagRequest extends AbstractRequest
     }
 
     /**
-     * @param  Person  ...$recipients
+     * @param Label $label
+     * @return $this
+     */
+    public function setLabel(Label $label): CreateTagRequest
+    {
+        $this->label = $label;
+        return $this;
+    }
+
+    public function getEmailNotificationDetail(): EmailNotificationDetail
+    {
+        return $this->emailNotificationDetail;
+    }
+
+    public function setEmailNotificationDetail(EmailNotificationDetail $emailNotificationDetail): static
+    {
+        $this->emailNotificationDetail = $emailNotificationDetail;
+
+        return $this;
+    }
+
+    /**
+     * @return Label
+     */
+    public function getLabel(): Label
+    {
+        return $this->label;
+    }
+
+    /**
+     * @param Person ...$recipients
      * @return $this
      */
     public function setRecipients(Person ...$recipients): CreateTagRequest
@@ -146,7 +183,7 @@ class CreateTagRequest extends AbstractRequest
     }
 
     /**
-     * @param  int  $account_number
+     * @param int $account_number
      * @return $this
      */
     public function setAccountNumber(int $account_number): CreateTagRequest
@@ -160,7 +197,7 @@ class CreateTagRequest extends AbstractRequest
      */
     public function prepare(): array
     {
-        return [
+        $data = [
             'json' => [
                 'labelResponseOptions' => 'LABEL',
                 'requestedShipment' => [
@@ -189,11 +226,6 @@ class CreateTagRequest extends AbstractRequest
                             'returnType' => 'PRINT_RETURN_LABEL',
                         ],
                     ],
-                    'labelSpecification' => [
-                        'labelFormatType' => 'COMMON2D',
-                        'imageType' => 'PNG',
-                        'labelStockType' => 'PAPER_7X475',
-                    ],
                     'requestedPackageLineItems' => [$this->getLineItems()->prepare()],
                 ],
                 'accountNumber' => [
@@ -201,13 +233,23 @@ class CreateTagRequest extends AbstractRequest
                 ],
             ],
         ];
+
+        if (!empty($this->label)) {
+            $data['json']['requestedShipment']['labelSpecification'] = $this->label->prepare();
+        }
+
+        if (!empty($this->emailNotificationDetail)) {
+            $data['json']['requestedShipment']['emailNotificationDetail'] = $this->emailNotificationDetail->prepare();
+        }
+
+        return $data;
     }
 
     /**
-     * @return mixed|\Psr\Http\Message\ResponseInterface|void
+     * @return mixed|ResponseInterface|void
      * @throws MissingAccountNumberException
      * @throws MissingLineItemException
-     * @throws \FedexRest\Exceptions\MissingAccessTokenException
+     * @throws MissingAccessTokenException|GuzzleException
      */
     public function request()
     {

--- a/src/FedexRest/Services/Ship/CreateTagRequest.php
+++ b/src/FedexRest/Services/Ship/CreateTagRequest.php
@@ -143,6 +143,14 @@ class CreateTagRequest extends AbstractRequest
     }
 
     /**
+     * @return Label
+     */
+    public function getLabel(): Label
+    {
+        return $this->label;
+    }
+
+    /**
      * @param Label $label
      * @return $this
      */
@@ -157,19 +165,11 @@ class CreateTagRequest extends AbstractRequest
         return $this->emailNotificationDetail;
     }
 
-    public function setEmailNotificationDetail(EmailNotificationDetail $emailNotificationDetail): static
+    public function setEmailNotificationDetail(EmailNotificationDetail $emailNotificationDetail): CreateTagRequest
     {
         $this->emailNotificationDetail = $emailNotificationDetail;
 
         return $this;
-    }
-
-    /**
-     * @return Label
-     */
-    public function getLabel(): Label
-    {
-        return $this->label;
     }
 
     /**

--- a/src/FedexRest/Services/Ship/Entity/Label.php
+++ b/src/FedexRest/Services/Ship/Entity/Label.php
@@ -6,6 +6,7 @@ class Label
 {
     public ?string $imageType;
     public ?string $labelStockType;
+    public ?string $labelFormatType;
 
     /**
      * @param string  $imageType
@@ -27,6 +28,16 @@ class Label
         return $this;
     }
 
+    /**
+     * @param string  $labelFormatType
+     * @return $this
+     */
+    public function setLabelFormatType(string $labelFormatType): Label
+    {
+        $this->labelFormatType = $labelFormatType;
+        return $this;
+    }
+
     public function prepare(): array
     {
         $data = [];
@@ -36,6 +47,10 @@ class Label
         if (!empty($this->imageType)) {
             $data['imageType'] = $this->imageType;
         }
+        if (!empty($this->labelFormatType)) {
+            $data['labelFormatType'] = $this->labelFormatType;
+        }
+
         return $data;
     }
 }

--- a/src/FedexRest/Services/Ship/Type/LabelFormatType.php
+++ b/src/FedexRest/Services/Ship/Type/LabelFormatType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace FedexRest\Services\Ship\Type;
+
+class LabelFormatType
+{
+    const _COMMON2D = 'COMMON2D';
+    const _LABEL_DATA_ONLY = 'LABEL_DATA_ONLY';
+}

--- a/tests/FedexRest/Tests/Ship/CreateTagRequestTest.php
+++ b/tests/FedexRest/Tests/Ship/CreateTagRequestTest.php
@@ -4,6 +4,7 @@ namespace FedexRest\Tests\Ship;
 
 use FedexRest\Authorization\Authorize;
 use FedexRest\Entity\Address;
+use FedexRest\Entity\EmailNotificationRecipient;
 use FedexRest\Entity\Item;
 use FedexRest\Entity\Person;
 use FedexRest\Entity\Weight;
@@ -12,6 +13,10 @@ use FedexRest\Exceptions\MissingAccountNumberException;
 use FedexRest\Exceptions\MissingAuthCredentialsException;
 use FedexRest\Exceptions\MissingLineItemException;
 use FedexRest\Services\Ship\CreateTagRequest;
+use FedexRest\Services\Ship\Entity\EmailNotificationDetail;
+use FedexRest\Services\Ship\Entity\Label;
+use FedexRest\Services\Ship\Type\ImageType;
+use FedexRest\Services\Ship\Type\LabelStockType;
 use FedexRest\Services\Ship\Type\PackagingType;
 use FedexRest\Services\Ship\Type\PickupType;
 use FedexRest\Services\Ship\Type\ServiceType;
@@ -61,6 +66,11 @@ class CreateTagRequestTest extends TestCase
             )
             ->setShipper(
                 (new Person)->setPersonName('Ipsum')
+            )
+            ->setLabel(
+                (new Label())
+                    ->setLabelStockType(LabelStockType::_PAPER_4X6)
+                    ->setImageType(ImageType::_PNG)
             );
         $this->assertCount(2, $request->getRecipients());
         $this->assertObjectHasProperty('personName', $request->getShipper());
@@ -92,6 +102,23 @@ class CreateTagRequestTest extends TestCase
                 (new Person)
                     ->setPersonName('Ipsum')
                     ->setPhoneNumber('1234567890')
+            )
+            ->setLabel(
+                (new Label())
+                    ->setLabelStockType(LabelStockType::_PAPER_4X6)
+                    ->setImageType(ImageType::_PNG)
+            )
+            ->setEmailNotificationDetail((new EmailNotificationDetail)
+                ->setPersonalMessage('hello world')
+                ->setAggregationType('PER_PACKAGE')
+                ->setEmailNotificationRecipients([
+                        (new EmailNotificationRecipient())
+                            ->setName('John Doe')
+                            ->setEmailAddress('john@doe.com')
+                            ->setNotificationEventType('ON_DELIVERY', 'ON_PICKUP_DRIVER_EN_ROUTE')
+                            ->setEmailNotificationRecipientType('SHIPPER')
+                    ]
+                )
             )
             ->setLineItems((new Item())
                 ->setItemDescription('lorem Ipsum')
@@ -140,6 +167,23 @@ class CreateTagRequestTest extends TestCase
                                 ->setCountryCode('US')
                                 ->setPostalCode('75063')
                         )
+                )
+                ->setLabel(
+                    (new Label())
+                        ->setLabelStockType(LabelStockType::_PAPER_4X6)
+                        ->setImageType(ImageType::_PNG)
+                )
+                ->setEmailNotificationDetail((new EmailNotificationDetail)
+                    ->setPersonalMessage('hello world')
+                    ->setAggregationType('PER_PACKAGE')
+                    ->setEmailNotificationRecipients([
+                            (new EmailNotificationRecipient())
+                                ->setName('John Doe')
+                                ->setEmailAddress('john@doe.com')
+                                ->setNotificationEventType('ON_DELIVERY', 'ON_PICKUP_DRIVER_EN_ROUTE')
+                                ->setEmailNotificationRecipientType('SHIPPER')
+                        ]
+                    )
                 )
                 ->setLineItems((new Item())
                     ->setItemDescription('lorem Ipsum')

--- a/tests/FedexRest/Tests/Ship/CreateTagRequestTest.php
+++ b/tests/FedexRest/Tests/Ship/CreateTagRequestTest.php
@@ -16,6 +16,7 @@ use FedexRest\Services\Ship\CreateTagRequest;
 use FedexRest\Services\Ship\Entity\EmailNotificationDetail;
 use FedexRest\Services\Ship\Entity\Label;
 use FedexRest\Services\Ship\Type\ImageType;
+use FedexRest\Services\Ship\Type\LabelFormatType;
 use FedexRest\Services\Ship\Type\LabelStockType;
 use FedexRest\Services\Ship\Type\PackagingType;
 use FedexRest\Services\Ship\Type\PickupType;
@@ -39,7 +40,7 @@ class CreateTagRequestTest extends TestCase
     {
         try {
             (new CreateTagRequest)
-                ->setAccessToken((string) $this->auth->authorize()->access_token)
+                ->setAccessToken((string)$this->auth->authorize()->access_token)
                 ->request();
 
         } catch (MissingAccountNumberException $e) {
@@ -51,7 +52,7 @@ class CreateTagRequestTest extends TestCase
     public function testRequiredData()
     {
         $request = (new CreateTagRequest)
-            ->setAccessToken((string) $this->auth->authorize()->access_token)
+            ->setAccessToken((string)$this->auth->authorize()->access_token)
             ->setAccountNumber(740561073)
             ->setServiceType(ServiceType::_FEDEX_GROUND)
             ->setRecipients(
@@ -70,6 +71,7 @@ class CreateTagRequestTest extends TestCase
                 (new Label())
                     ->setLabelStockType(LabelStockType::_PAPER_4X6)
                     ->setImageType(ImageType::_PNG)
+                    ->setLabelFormatType(LabelFormatType::_COMMON2D)
             );
         $this->assertCount(2, $request->getRecipients());
         $this->assertObjectHasProperty('personName', $request->getShipper());
@@ -79,7 +81,7 @@ class CreateTagRequestTest extends TestCase
     public function testPrepare()
     {
         $request = (new CreateTagRequest)
-            ->setAccessToken((string) $this->auth->authorize()->access_token)
+            ->setAccessToken((string)$this->auth->authorize()->access_token)
             ->setAccountNumber(740561073)
             ->setServiceType(ServiceType::_FEDEX_GROUND)
             ->setPackagingType(PackagingType::_YOUR_PACKAGING)
@@ -106,6 +108,7 @@ class CreateTagRequestTest extends TestCase
                 (new Label())
                     ->setLabelStockType(LabelStockType::_PAPER_4X6)
                     ->setImageType(ImageType::_PNG)
+                    ->setLabelFormatType(LabelFormatType::_COMMON2D)
             )
             ->setEmailNotificationDetail((new EmailNotificationDetail)
                 ->setPersonalMessage('hello world')
@@ -130,7 +133,7 @@ class CreateTagRequestTest extends TestCase
 
         $this->assertEquals('Boston', $prepared['json']['requestedShipment']['recipients'][0]['address']['city']);
         $this->assertEquals(LabelStockType::_PAPER_4X6, $prepared['json']['requestedShipment']['labelSpecification']['labelStockType']);
-        $this->assertEquals(LabelStockType::_PAPER_4X6, $prepared['json']['requestedShipment']['emailNotificationDetail']['emailNotificationRecipients'][0]['emailAddress'] === 'john@doe.com');
+        $this->assertEquals('john@doe.com', $prepared['json']['requestedShipment']['emailNotificationDetail']['emailNotificationRecipients'][0]['emailAddress']);
     }
 
     public function testRequest()
@@ -138,7 +141,7 @@ class CreateTagRequestTest extends TestCase
         try {
             $request = (new CreateTagRequest())
                 ->asRaw()
-                ->setAccessToken((string) $this->auth->authorize()->access_token)
+                ->setAccessToken((string)$this->auth->authorize()->access_token)
                 ->setAccountNumber(740561073)
                 ->setServiceType(ServiceType::_FEDEX_GROUND)
                 ->setPackagingType(PackagingType::_YOUR_PACKAGING)
@@ -195,7 +198,7 @@ class CreateTagRequestTest extends TestCase
                             ->setUnit('LB')
                     ))
                 ->request();
-        } catch (MissingAccountNumberException | MissingAuthCredentialsException | GuzzleException $e) {
+        } catch (MissingAccountNumberException|MissingAuthCredentialsException|GuzzleException $e) {
             $this->assertEmpty($e, sprintf('The request failed with message %s', $e->getMessage()));
         }
 

--- a/tests/FedexRest/Tests/Ship/CreateTagRequestTest.php
+++ b/tests/FedexRest/Tests/Ship/CreateTagRequestTest.php
@@ -50,7 +50,6 @@ class CreateTagRequestTest extends TestCase
 
     public function testRequiredData()
     {
-
         $request = (new CreateTagRequest)
             ->setAccessToken((string) $this->auth->authorize()->access_token)
             ->setAccountNumber(740561073)
@@ -128,7 +127,10 @@ class CreateTagRequestTest extends TestCase
                         ->setUnit('LB')
                 ));
         $prepared = $request->prepare();
+
         $this->assertEquals('Boston', $prepared['json']['requestedShipment']['recipients'][0]['address']['city']);
+        $this->assertEquals(LabelStockType::_PAPER_4X6, $prepared['json']['requestedShipment']['labelSpecification']['labelStockType']);
+        $this->assertEquals(LabelStockType::_PAPER_4X6, $prepared['json']['requestedShipment']['emailNotificationDetail']['emailNotificationRecipients'][0]['emailAddress'] === 'john@doe.com');
     }
 
     public function testRequest()


### PR DESCRIPTION
Use the same label and email notification functionality as CreateShipment.