### PR TITLE
Support for Customer Reference and Unit Tests

### DIFF
--- a/src/FedexRest/Entity/CustomerReference.php
+++ b/src/FedexRest/Entity/CustomerReference.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace FedexRest\Entity;
+
+class CustomerReference
+{
+    public string $type;
+    public string $value;
+
+    public function setType(string $type): CustomerReference
+    {
+        $this->type = $type;
+        return $this;
+    }
+
+    public function setValue(string $value): CustomerReference
+    {
+        $this->value = $value;
+        return $this;
+    }
+
+    public function prepare(): array {
+        $data = [];
+        if (!empty($this->type)) {
+            $data['customerReferenceType'] = $this->type;
+            $data['value'] = $this->value;
+        }
+        return $data;
+    }
+
+
+}

--- a/src/FedexRest/Entity/Item.php
+++ b/src/FedexRest/Entity/Item.php
@@ -2,6 +2,7 @@
 
 namespace FedexRest\Entity;
 
+use FedexRest\Entity\CustomerReference;
 use FedexRest\Services\Ship\Entity\Value;
 
 class Item
@@ -14,6 +15,7 @@ class Item
     public ?string $subPackagingType;
     public ?Value $declaredValue;
     public ?PackageSpecialServicesRequested $packageSpecialServices;
+    public array $customerReferences = [];
 
     /**
      * @param  string  $itemDescription
@@ -95,6 +97,26 @@ class Item
     return $this;
   }
 
+  /**
+   * @param  CustomerReference[]  $customerReferences
+   * @return Item
+   */
+  public function setCustomerReferences(array $customerReferences): Item
+  {
+      $this->customerReferences = $customerReferences;
+      return $this;
+  }
+
+  /**
+   * @param  CustomerReference  $customerReference
+   * @return Item
+   */
+  public function addCustomerReference(CustomerReference $customerReference): Item
+  {
+      $this->customerReferences[] = $customerReference;
+      return $this;
+  }
+
     public function prepare(): array
     {
         $data = [];
@@ -129,6 +151,14 @@ class Item
 
         if (!empty($this->packageSpecialServices)) {
             $data['packageSpecialServices'] = $this->packageSpecialServices->prepare();
+        }
+
+        if (!empty($this->customerReferences)) {
+            $customerReferences = [];
+            foreach ($this->customerReferences as $customerReference) {
+                $customerReferences[] = $customerReference->prepare();
+            }
+            $data['customerReferences'] = $customerReferences;
         }
 
         return $data;

--- a/src/FedexRest/Services/Ship/Type/CustomerReferenceType.php
+++ b/src/FedexRest/Services/Ship/Type/CustomerReferenceType.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace FedexRest\Services\Ship\Type;
+
+class CustomerReferenceType
+{
+
+    const _CUSTOMER_REFERENCE = 'CUSTOMER_REFERENCE';
+    const _DEPARTMENT_NUMBER = 'DEPARTMENT_NUMBER';
+    const _INVOICE_NUMBER = 'INVOICE_NUMBER';
+    const _P_O_NUMBER = 'P_O_NUMBER';
+    const _INTRACOUNTRY_REGULATORY_REFERENCE = 'INTRACOUNTRY_REGULATORY_REFERENCE';
+    const _RMA_ASSOCIATION = 'RMA_ASSOCIATION';
+
+}

--- a/tests/FedexRest/Tests/Entity/ItemEntityTest.php
+++ b/tests/FedexRest/Tests/Entity/ItemEntityTest.php
@@ -2,17 +2,19 @@
 
 namespace FedexRest\Tests\Entity;
 
-use FedexRest\Entity\DangerousGoodsDetail;
-use FedexRest\Entity\Dimensions;
 use FedexRest\Entity\Item;
-use FedexRest\Entity\PackageSpecialServicesRequested;
 use FedexRest\Entity\Weight;
-use FedexRest\Services\Ship\Entity\Value;
-use FedexRest\Services\Ship\Type\DangerousGoodsAccessibilityType;
-use FedexRest\Services\Ship\Type\LinearUnits;
-use FedexRest\Services\Ship\Type\SubPackagingType;
-use FedexRest\Services\Ship\Type\WeightUnits;
 use PHPUnit\Framework\TestCase;
+use FedexRest\Entity\Dimensions;
+use FedexRest\Entity\CustomerReference;
+use FedexRest\Services\Ship\Entity\Value;
+use FedexRest\Entity\DangerousGoodsDetail;
+use FedexRest\Services\Ship\Type\LinearUnits;
+use FedexRest\Services\Ship\Type\WeightUnits;
+use FedexRest\Services\Ship\Type\SubPackagingType;
+use FedexRest\Entity\PackageSpecialServicesRequested;
+use FedexRest\Services\Ship\Type\CustomerReferenceType;
+use FedexRest\Services\Ship\Type\DangerousGoodsAccessibilityType;
 
 class ItemEntityTest extends TestCase
 {
@@ -42,6 +44,10 @@ class ItemEntityTest extends TestCase
                   (new DangerousGoodsDetail())
                     ->setAccessibility(DangerousGoodsAccessibilityType::_ACCESSIBLE)
                 )
+            )->addCustomerReference(
+                (new CustomerReference())
+                    ->setType(CustomerReferenceType::_CUSTOMER_REFERENCE)
+                    ->setValue('123456')
             );
         $this->assertObjectHasProperty('itemDescription', $item);
         $this->assertObjectHasProperty('dimensions', $item);
@@ -51,6 +57,7 @@ class ItemEntityTest extends TestCase
         $this->assertObjectHasProperty('subPackagingType', $item);
         $this->assertObjectHasProperty('declaredValue', $item);
         $this->assertObjectHasProperty('packageSpecialServices', $item);
+        $this->assertObjectHasProperty('customerReferences', $item);
         $test_item = $item->prepare();
         $this->assertEquals(1, $test_item['weight']['value']);
         $this->assertEquals(WeightUnits::_POUND, $test_item['weight']['units']);
@@ -64,5 +71,7 @@ class ItemEntityTest extends TestCase
         $this->assertEquals(100, $test_item['declaredValue']['amount']);
         $this->assertEquals('USD', $test_item['declaredValue']['currency']);
         $this->assertEquals(DangerousGoodsAccessibilityType::_ACCESSIBLE, $test_item['packageSpecialServices']['dangerousGoodsDetail']['accessibility']);
+        $this->assertEquals(CustomerReferenceType::_CUSTOMER_REFERENCE, $test_item['customerReferences'][0]['customerReferenceType']);
+        $this->assertEquals('123456', $test_item['customerReferences'][0]['value']);
     }
 }

--- a/tests/FedexRest/Tests/Ship/CreateShipmentTest.php
+++ b/tests/FedexRest/Tests/Ship/CreateShipmentTest.php
@@ -2,35 +2,37 @@
 
 namespace FedexRest\Tests\Ship;
 
-use FedexRest\Authorization\Authorize;
-use FedexRest\Entity\Address;
-use FedexRest\Entity\Dimensions;
-use FedexRest\Entity\EmailNotificationRecipient;
 use FedexRest\Entity\Item;
-use FedexRest\Exceptions\MissingAccessTokenException;
-use FedexRest\Exceptions\MissingAuthCredentialsException;
-use FedexRest\Exceptions\MissingLineItemException;
-use FedexRest\Services\Ship\Entity\EmailNotificationDetail;
-use FedexRest\Services\Ship\Entity\Label;
 use FedexRest\Entity\Person;
-use FedexRest\Services\Ship\Entity\ShippingChargesPayment;
 use FedexRest\Entity\Weight;
+use FedexRest\Entity\Address;
+use PHPUnit\Framework\TestCase;
+use FedexRest\Entity\Dimensions;
+use FedexRest\Authorization\Authorize;
+use FedexRest\Entity\CustomerReference;
+use FedexRest\Services\Ship\Entity\Label;
+use GuzzleHttp\Exception\GuzzleException;
+use FedexRest\Services\Ship\CreateShipment;
+use FedexRest\Services\Ship\Type\ImageType;
+use FedexRest\Services\Ship\Type\PickupType;
+use FedexRest\Services\Ship\Type\LinearUnits;
+use FedexRest\Services\Ship\Type\ServiceType;
+use FedexRest\Services\Ship\Type\WeightUnits;
+use FedexRest\Services\Ship\Type\PackagingType;
+use FedexRest\Entity\EmailNotificationRecipient;
+use FedexRest\Services\Ship\Type\LabelStockType;
+use FedexRest\Exceptions\MissingLineItemException;
+use FedexRest\Services\Ship\Type\LabelDocOptionType;
+use FedexRest\Exceptions\MissingAccessTokenException;
 use FedexRest\Exceptions\MissingAccountNumberException;
+use FedexRest\Exceptions\MissingAuthCredentialsException;
+use FedexRest\Services\Ship\Entity\ShippingChargesPayment;
+use FedexRest\Services\Ship\Type\LabelResponseOptionsType;
+use FedexRest\Services\Ship\Entity\EmailNotificationDetail;
 use FedexRest\Services\Ship\Exceptions\MissingLabelException;
 use FedexRest\Services\Ship\Exceptions\MissingLabelResponseOptionsException;
 use FedexRest\Services\Ship\Exceptions\MissingShippingChargesPaymentException;
-use FedexRest\Services\Ship\CreateShipment;
-use FedexRest\Services\Ship\Type\ImageType;
-use FedexRest\Services\Ship\Type\LabelDocOptionType;
-use FedexRest\Services\Ship\Type\LabelResponseOptionsType;
-use FedexRest\Services\Ship\Type\LabelStockType;
-use FedexRest\Services\Ship\Type\LinearUnits;
-use FedexRest\Services\Ship\Type\PackagingType;
-use FedexRest\Services\Ship\Type\PickupType;
-use FedexRest\Services\Ship\Type\ServiceType;
-use FedexRest\Services\Ship\Type\WeightUnits;
-use GuzzleHttp\Exception\GuzzleException;
-use PHPUnit\Framework\TestCase;
+use FedexRest\Services\Ship\Type\CustomerReferenceType;
 
 class CreateShipmentTest extends TestCase
 {
@@ -413,6 +415,14 @@ class CreateShipmentTest extends TestCase
                     ->setLength(12)
                     ->setHeight(12)
                     ->setUnits(LinearUnits::_INCH)
+                )->addCustomerReference(
+                    (new CustomerReference())
+                        ->setType(CustomerReferenceType::_CUSTOMER_REFERENCE)
+                        ->setValue('123456')
+                )->addCustomerReference(
+                    (new CustomerReference())
+                        ->setType(CustomerReferenceType::_INVOICE_NUMBER)
+                        ->setValue('INVOICE')
                 )
             )
             ->setEmailNotificationDetail((new EmailNotificationDetail)
@@ -441,6 +451,8 @@ class CreateShipmentTest extends TestCase
         $this->assertNotEmpty($new_shipment->pieceResponses);
         $this->assertNotEmpty($new_shipment->completedShipmentDetail);
         $this->assertEquals('GROUND', $new_shipment->serviceCategory);
+        $this->assertNotEmpty($new_shipment->pieceResponses[0]->customerReferences);
+
     }
 
 }


### PR DESCRIPTION
This is built upon what @staticglobal did.. Made some tweaks and added unit tests.
Let me know your thoughts and what else may be needed to be included in the main library.

Business case for Customer References:
- Most of them show up on the actual label (helps to identify what the label is for when doing bulk label printing)
- Most of these references show up in FedEx Invoices -- really helpful to find all packages in invoice or find all shipments with specific Reference in general