### PR TITLE
Update "Account Number" field type from `int` to `string`.

### DIFF
--- a/src/FedexRest/Services/Pickup/CancelPickup.php
+++ b/src/FedexRest/Services/Pickup/CancelPickup.php
@@ -8,7 +8,7 @@ use FedexRest\Services\Pickup\Entity\AccountAddressOfRecord;
 class CancelPickup extends AbstractRequest
 {
 
-    protected int $associatedAccountNumber;
+    protected ?string $associatedAccountNumber = null;
     protected string $pickupConfirmationCode;
     protected ?string $remarks = null;
     protected ?string $carrierCode = null;
@@ -17,18 +17,18 @@ class CancelPickup extends AbstractRequest
     protected ?string $location = null;
 
     /**
-     * @return int
+     * @return ?string
      */
-    public function getAssociatedAccountNumber(): int
+    public function getAssociatedAccountNumber(): ?string
     {
         return $this->associatedAccountNumber;
     }
 
     /**
-     * @param int $associatedAccountNumber
+     * @param string|null $associatedAccountNumber
      * @return CancelPickup
      */
-    public function setAssociatedAccountNumber(int $associatedAccountNumber): CancelPickup
+    public function setAssociatedAccountNumber(?string $associatedAccountNumber): CancelPickup
     {
         $this->associatedAccountNumber = $associatedAccountNumber;
         return $this;

--- a/src/FedexRest/Services/Pickup/CreatePickup.php
+++ b/src/FedexRest/Services/Pickup/CreatePickup.php
@@ -11,7 +11,7 @@ use FedexRest\Services\AbstractRequest;
 
 class CreatePickup extends AbstractRequest
 {
-    protected int $associatedAccountNumber;
+    protected ?string $associatedAccountNumber = null;
     protected OriginDetail $originDetail;
     protected ?string $associatedAccountNumberType = null;
     protected ?Weight $totalWeight = null;
@@ -28,18 +28,18 @@ class CreatePickup extends AbstractRequest
     protected ?PickupNotificationDetail $pickupNotificationDetail = null;
 
     /**
-     * @return int
+     * @return string|null
      */
-    public function getAssociatedAccountNumber(): int
+    public function getAssociatedAccountNumber(): ?string
     {
         return $this->associatedAccountNumber;
     }
 
     /**
-     * @param int $associatedAccountNumber
+     * @param string|null $associatedAccountNumber
      * @return CreatePickup
      */
-    public function setAssociatedAccountNumber(int $associatedAccountNumber): CreatePickup
+    public function setAssociatedAccountNumber(?string $associatedAccountNumber): CreatePickup
     {
         $this->associatedAccountNumber = $associatedAccountNumber;
         return $this;

--- a/src/FedexRest/Services/Rates/CreateRatesRequest.php
+++ b/src/FedexRest/Services/Rates/CreateRatesRequest.php
@@ -24,7 +24,7 @@ class CreateRatesRequest extends AbstractRequest
     protected array $rateRequestTypes;
     protected string $packagingType = '';
     protected string $pickupType = '';
-    protected int $accountNumber;
+    protected ?string $accountNumber = null;
     protected array $lineItems = [];
     protected ShipmentSpecialServices $shipmentSpecialServices;
     protected ShippingChargesPayment $shippingChargesPayment;
@@ -155,10 +155,10 @@ class CreateRatesRequest extends AbstractRequest
     }
 
     /**
-     * @param int $accountNumber
+     * @param string|null $accountNumber
      * @return $this
      */
-    public function setAccountNumber(int $accountNumber): CreateRatesRequest
+    public function setAccountNumber(?string $accountNumber): CreateRatesRequest
     {
         $this->accountNumber = $accountNumber;
         return $this;

--- a/src/FedexRest/Services/Ship/CancelShipment.php
+++ b/src/FedexRest/Services/Ship/CancelShipment.php
@@ -10,7 +10,7 @@ use GuzzleHttp\Exception\GuzzleException;
 
 class CancelShipment extends AbstractRequest
 {
-    protected int $accountNumber;
+    protected ?string $accountNumber = null;
     protected string $trackingNumber;
 
     public function setApiEndpoint(): string
@@ -19,10 +19,10 @@ class CancelShipment extends AbstractRequest
     }
 
     /**
-     * @param int $accountNumber
+     * @param string|null $accountNumber
      * @return $this
      */
-    public function setAccountNumber(int $accountNumber): CancelShipment
+    public function setAccountNumber(?string $accountNumber): CancelShipment
     {
         $this->accountNumber = $accountNumber;
         return $this;

--- a/src/FedexRest/Services/Ship/CreateShipment.php
+++ b/src/FedexRest/Services/Ship/CreateShipment.php
@@ -27,7 +27,7 @@ class CreateShipment extends AbstractRequest
     protected string $serviceType;
     protected string $packagingType = '';
     protected string $pickupType = '';
-    protected int $accountNumber;
+    protected ?string $accountNumber = null;
     protected array $rateRequestTypes;
     protected array $lineItems = [];
     protected string $labelResponseOptions = '';
@@ -158,10 +158,10 @@ class CreateShipment extends AbstractRequest
     }
 
     /**
-     * @param  int  $accountNumber
+     * @param  string|null  $accountNumber
      * @return $this
      */
-    public function setAccountNumber(int $accountNumber): CreateShipment {
+    public function setAccountNumber(?string $accountNumber): CreateShipment {
         $this->accountNumber = $accountNumber;
         return $this;
     }

--- a/src/FedexRest/Services/Ship/CreateTagRequest.php
+++ b/src/FedexRest/Services/Ship/CreateTagRequest.php
@@ -15,7 +15,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class CreateTagRequest extends AbstractRequest
 {
-    protected int $account_number;
+    protected ?string $account_number = null;
     protected Person $shipper;
     protected array $recipients;
     protected ?Item $line_items;
@@ -183,10 +183,10 @@ class CreateTagRequest extends AbstractRequest
     }
 
     /**
-     * @param int $account_number
+     * @param string|null $account_number
      * @return $this
      */
-    public function setAccountNumber(int $account_number): CreateTagRequest
+    public function setAccountNumber(?string $account_number): CreateTagRequest
     {
         $this->account_number = $account_number;
         return $this;

--- a/tests/FedexRest/Tests/Pickup/CancelPickupTest.php
+++ b/tests/FedexRest/Tests/Pickup/CancelPickupTest.php
@@ -25,7 +25,7 @@ class CancelPickupTest extends TestCase
     {
         $request = (new CancelPickup())
             ->setAccessToken((string) $this->auth->authorize()->access_token)
-            ->setAssociatedAccountNumber(740561073)
+            ->setAssociatedAccountNumber('740561073')
             ->setPickupConfirmationCode('1')
             ->setCarrierCode('FDXE')
             ->setScheduledDate('2020-07-03')

--- a/tests/FedexRest/Tests/Pickup/CreatePickupTest.php
+++ b/tests/FedexRest/Tests/Pickup/CreatePickupTest.php
@@ -44,7 +44,7 @@ class CreatePickupTest extends TestCase
     {
         $pickup = (new CreatePickup())
             ->setAccessToken((string)$this->auth->authorize()->access_token)
-            ->setAssociatedAccountNumber(740561073)
+            ->setAssociatedAccountNumber('740561073')
             ->setOriginDetail(
                 (new OriginDetail())->setPickupLocation(
                     (new PickupLocation())->setContact(

--- a/tests/FedexRest/Tests/Rates/CreateRatesRequestTest.php
+++ b/tests/FedexRest/Tests/Rates/CreateRatesRequestTest.php
@@ -55,7 +55,7 @@ class CreateRatesRequestTest extends TestCase
     {
         $createRatesRequest = (new CreateRatesRequest())
             ->setAccessToken((string)$this->auth->authorize()->access_token)
-            ->setAccountNumber(740561073)
+            ->setAccountNumber('740561073')
             ->setServiceType(ServiceType::_FEDEX_GROUND)
             ->setRecipient(
                 (new Person)
@@ -89,7 +89,7 @@ class CreateRatesRequestTest extends TestCase
     {
         $request = (new CreateRatesRequest)
             ->setAccessToken((string)$this->auth->authorize()->access_token)
-            ->setAccountNumber(740561073)
+            ->setAccountNumber('740561073')
             ->setServiceType(ServiceType::_FEDEX_GROUND)
             ->setPackagingType(PackagingType::_YOUR_PACKAGING)
             ->setPickupType(PickupType::_DROPOFF_AT_FEDEX_LOCATION)
@@ -150,7 +150,7 @@ class CreateRatesRequestTest extends TestCase
     {
         $request = (new CreateRatesRequest)
             ->setAccessToken((string)$this->auth->authorize()->access_token)
-            ->setAccountNumber(740561073)
+            ->setAccountNumber('740561073')
             ->setRateRequestTypes('ACCOUNT', 'LIST')
             ->setPickupType(PickupType::_DROPOFF_AT_FEDEX_LOCATION)
             ->setShipper(

--- a/tests/FedexRest/Tests/Ship/CancelShipmentTest.php
+++ b/tests/FedexRest/Tests/Ship/CancelShipmentTest.php
@@ -40,7 +40,7 @@ class CancelShipmentTest extends TestCase
         try {
             $request = (new CancelShipment())
                 ->setAccessToken((string) $this->auth->authorize()->access_token)
-                ->setAccountNumber(740561073)
+                ->setAccountNumber('740561073')
                 ->request();
 
         } catch (MissingTrackingNumberException $e) {
@@ -53,7 +53,7 @@ class CancelShipmentTest extends TestCase
     {
         $request = (new CancelShipment)
             ->setAccessToken((string) $this->auth->authorize()->access_token)
-            ->setAccountNumber($accountNumber = 740561073)
+            ->setAccountNumber($accountNumber = '740561073')
             ->setTrackingNumber($trackingNumber = 794953555571);
 
         $this->assertEquals($accountNumber, $request->prepare()['accountNumber']['value']);
@@ -64,7 +64,7 @@ class CancelShipmentTest extends TestCase
     {
         $cancelShipment = (new CancelShipment)
             ->setAccessToken((string) $this->auth->authorize()->access_token)
-            ->setAccountNumber(740561073)
+            ->setAccountNumber('740561073')
             ->setTrackingNumber(794953555571);
 
         $request = $cancelShipment->request();

--- a/tests/FedexRest/Tests/Ship/CreateShipmentTest.php
+++ b/tests/FedexRest/Tests/Ship/CreateShipmentTest.php
@@ -65,7 +65,7 @@ class CreateShipmentTest extends TestCase
         try {
             $request = (new CreateShipment())
                 ->setAccessToken((string)$this->auth->authorize()->access_token)
-                ->setAccountNumber(740561073)
+                ->setAccountNumber('740561073')
                 ->setServiceType(ServiceType::_FEDEX_GROUND)
                 ->setPackagingType(PackagingType::_YOUR_PACKAGING)
                 ->setPickupType(PickupType::_DROPOFF_AT_FEDEX_LOCATION)
@@ -130,7 +130,7 @@ class CreateShipmentTest extends TestCase
         try {
             $request = (new CreateShipment())
                 ->setAccessToken((string)$this->auth->authorize()->access_token)
-                ->setAccountNumber(740561073)
+                ->setAccountNumber('740561073')
                 ->setServiceType(ServiceType::_FEDEX_GROUND)
                 ->setPackagingType(PackagingType::_YOUR_PACKAGING)
                 ->setPickupType(PickupType::_DROPOFF_AT_FEDEX_LOCATION)
@@ -192,7 +192,7 @@ class CreateShipmentTest extends TestCase
         try {
             $request = (new CreateShipment)
                 ->setAccessToken((string)$this->auth->authorize()->access_token)
-                ->setAccountNumber(740561073)
+                ->setAccountNumber('740561073')
                 ->setServiceType(ServiceType::_FEDEX_GROUND)
                 ->setLabelResponseOptions(LabelResponseOptionsType::_URL_ONLY)
                 ->setPackagingType(PackagingType::_YOUR_PACKAGING)
@@ -241,7 +241,7 @@ class CreateShipmentTest extends TestCase
     {
         $shipment = (new CreateShipment())
             ->setAccessToken((string)$this->auth->authorize()->access_token)
-            ->setAccountNumber(740561073)
+            ->setAccountNumber('740561073')
             ->setServiceType(ServiceType::_FEDEX_GROUND)
             ->setLabelResponseOptions(LabelResponseOptionsType::_URL_ONLY)
             ->setShippingChargesPayment((new ShippingChargesPayment())
@@ -275,7 +275,7 @@ class CreateShipmentTest extends TestCase
     {
         $request = (new CreateShipment)
             ->setAccessToken((string)$this->auth->authorize()->access_token)
-            ->setAccountNumber(740561073)
+            ->setAccountNumber('740561073')
             ->setServiceType(ServiceType::_FEDEX_GROUND)
             ->setLabelResponseOptions(LabelResponseOptionsType::_URL_ONLY)
             ->setPackagingType(PackagingType::_YOUR_PACKAGING)
@@ -362,7 +362,7 @@ class CreateShipmentTest extends TestCase
     {
         $shipment = (new CreateShipment())
             ->setAccessToken((string)$this->auth->authorize()->access_token)
-            ->setAccountNumber(740561073)
+            ->setAccountNumber('740561073')
             ->setServiceType(ServiceType::_FEDEX_GROUND)
             ->setLabelResponseOptions(LabelResponseOptionsType::_URL_ONLY)
             ->setPackagingType(PackagingType::_YOUR_PACKAGING)

--- a/tests/FedexRest/Tests/Ship/CreateTagRequestTest.php
+++ b/tests/FedexRest/Tests/Ship/CreateTagRequestTest.php
@@ -53,7 +53,7 @@ class CreateTagRequestTest extends TestCase
     {
         $request = (new CreateTagRequest)
             ->setAccessToken((string)$this->auth->authorize()->access_token)
-            ->setAccountNumber(740561073)
+            ->setAccountNumber('740561073')
             ->setServiceType(ServiceType::_FEDEX_GROUND)
             ->setRecipients(
                 (new Person)->setPersonName('Lorem')
@@ -82,7 +82,7 @@ class CreateTagRequestTest extends TestCase
     {
         $request = (new CreateTagRequest)
             ->setAccessToken((string)$this->auth->authorize()->access_token)
-            ->setAccountNumber(740561073)
+            ->setAccountNumber('740561073')
             ->setServiceType(ServiceType::_FEDEX_GROUND)
             ->setPackagingType(PackagingType::_YOUR_PACKAGING)
             ->setPickupType(PickupType::_DROPOFF_AT_FEDEX_LOCATION)
@@ -142,7 +142,7 @@ class CreateTagRequestTest extends TestCase
             $request = (new CreateTagRequest())
                 ->asRaw()
                 ->setAccessToken((string)$this->auth->authorize()->access_token)
-                ->setAccountNumber(740561073)
+                ->setAccountNumber('740561073')
                 ->setServiceType(ServiceType::_FEDEX_GROUND)
                 ->setPackagingType(PackagingType::_YOUR_PACKAGING)
                 ->setPickupType(PickupType::_DROPOFF_AT_FEDEX_LOCATION)


### PR DESCRIPTION
Closes issue #39 "Account numbers with leading zeros are stripped when cast to int"