### PR TITLE
Truncate state_or_province to two characters

### DIFF
--- a/src/FedexRest/Entity/Address.php
+++ b/src/FedexRest/Entity/Address.php
@@ -81,7 +81,8 @@ class Address
             $address['city'] = $this->city;
         }
         if (!empty($this->state_or_province)) {
-            $address['stateOrProvinceCode'] = $this->state_or_province;
+            // Truncate the state/provice code to work around a limitation in FedEx's API.
+            $address['stateOrProvinceCode'] = substr($this->state_or_province, 0, 2);
         }
         if (!empty($this->postal_code)) {
             $address['postalCode'] = $this->postal_code;

--- a/src/FedexRest/Entity/Address.php
+++ b/src/FedexRest/Entity/Address.php
@@ -81,7 +81,7 @@ class Address
             $address['city'] = $this->city;
         }
         if (!empty($this->state_or_province)) {
-            // Truncate the state/provice code to work around a limitation in FedEx's API.
+            // Truncate the state/province code to work around a limitation in FedEx's API.
             $address['stateOrProvinceCode'] = substr($this->state_or_province, 0, 2);
         }
         if (!empty($this->postal_code)) {


### PR DESCRIPTION
Some countries will have state_or_province codes that are longer than two characters. FedEx's API will fail if this value is longer than two. Truncate the string to two characters to avoid such errors.

Resolves #42.